### PR TITLE
#29 feat(alamofire): API 레이어 구조화 및 interceptor 적용

### DIFF
--- a/campick.xcodeproj/project.pbxproj
+++ b/campick.xcodeproj/project.pbxproj
@@ -8,8 +8,20 @@
 
 /* Begin PBXBuildFile section */
 		84BFE9FE2E7AB856007068D4 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 84BFE9FD2E7AB856007068D4 /* Alamofire */; };
-		84BFEA002E7AB856007068D4 /* AlamofireDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 84BFE9FF2E7AB856007068D4 /* AlamofireDynamic */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		84BFEA0A2E7AC2FE007068D4 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		8463C3BA2E77B055006379CA /* campick.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = campick.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -42,7 +54,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				84BFE9FE2E7AB856007068D4 /* Alamofire in Frameworks */,
-				84BFEA002E7AB856007068D4 /* AlamofireDynamic in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -53,6 +64,7 @@
 			isa = PBXGroup;
 			children = (
 				8463C3BC2E77B055006379CA /* campick */,
+				84BFEA082E7AC2EB007068D4 /* Frameworks */,
 				8463C3BB2E77B055006379CA /* Products */,
 			);
 			sourceTree = "<group>";
@@ -65,6 +77,13 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		84BFEA082E7AC2EB007068D4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -75,6 +94,7 @@
 				8463C3B62E77B055006379CA /* Sources */,
 				8463C3B72E77B055006379CA /* Frameworks */,
 				8463C3B82E77B055006379CA /* Resources */,
+				84BFEA0A2E7AC2FE007068D4 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -86,7 +106,6 @@
 			name = campick;
 			packageProductDependencies = (
 				84BFE9FD2E7AB856007068D4 /* Alamofire */,
-				84BFE9FF2E7AB856007068D4 /* AlamofireDynamic */,
 			);
 			productName = campick;
 			productReference = 8463C3BA2E77B055006379CA /* campick.app */;
@@ -364,11 +383,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 84BFE9FC2E7AB856007068D4 /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
-		};
-		84BFE9FF2E7AB856007068D4 /* AlamofireDynamic */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 84BFE9FC2E7AB856007068D4 /* XCRemoteSwiftPackageReference "Alamofire" */;
-			productName = AlamofireDynamic;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/campick.xcodeproj/project.pbxproj
+++ b/campick.xcodeproj/project.pbxproj
@@ -6,6 +6,11 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		84BFE9FE2E7AB856007068D4 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 84BFE9FD2E7AB856007068D4 /* Alamofire */; };
+		84BFEA002E7AB856007068D4 /* AlamofireDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 84BFE9FF2E7AB856007068D4 /* AlamofireDynamic */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		8463C3BA2E77B055006379CA /* campick.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = campick.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -36,6 +41,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84BFE9FE2E7AB856007068D4 /* Alamofire in Frameworks */,
+				84BFEA002E7AB856007068D4 /* AlamofireDynamic in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +85,8 @@
 			);
 			name = campick;
 			packageProductDependencies = (
+				84BFE9FD2E7AB856007068D4 /* Alamofire */,
+				84BFE9FF2E7AB856007068D4 /* AlamofireDynamic */,
 			);
 			productName = campick;
 			productReference = 8463C3BA2E77B055006379CA /* campick.app */;
@@ -107,6 +116,9 @@
 			);
 			mainGroup = 8463C3B12E77B055006379CA;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				84BFE9FC2E7AB856007068D4 /* XCRemoteSwiftPackageReference "Alamofire" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 8463C3BB2E77B055006379CA /* Products */;
 			projectDirPath = "";
@@ -335,6 +347,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		84BFE9FC2E7AB856007068D4 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.10.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		84BFE9FD2E7AB856007068D4 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84BFE9FC2E7AB856007068D4 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+		84BFE9FF2E7AB856007068D4 /* AlamofireDynamic */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84BFE9FC2E7AB856007068D4 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = AlamofireDynamic;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 8463C3B22E77B055006379CA /* Project object */;
 }

--- a/campick/Info.plist
+++ b/campick/Info.plist
@@ -2,17 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
+    <key>NSAppTransportSecurity</key>
     <dict>
     <key>NSAllowsArbitraryLoads</key>
     <true/>
     </dict>
-	<dict/>
-	<key>CFBundleIdentifier</key>
-	<string></string>
-	<key>UIAppFonts</key>
-	<array>
-		<string>Pacifico-Regular.ttf</string>
-	</array>
+    <key>CFBundleIdentifier</key>
+    <string></string>
+    <key>UIAppFonts</key>
+    <array>
+        <string>Pacifico-Regular.ttf</string>
+    </array>
 </dict>
 </plist>

--- a/campick/Services/Network/APIService.swift
+++ b/campick/Services/Network/APIService.swift
@@ -1,0 +1,32 @@
+//
+//  APIService.swift
+//  campick
+//
+//  Created by oyun on 9/17/25.
+//
+
+import Foundation
+import Alamofire
+
+
+// MARK: - 실제 HTTP 요청을 보내는 역할을 합니다.
+
+
+// MARK: - 네트워크 요청을 담당하는 공통 APIService
+// Alamofire의 Session을 싱글톤(shared)으로 만들어 어디서든 재사용 가능
+final class APIService {
+    
+    // static let shared → 앱 전체에서 하나만 존재하는 공용 세션
+    static let shared: Session = {
+        // URLSession 기본 설정 가져오기
+        let config = URLSessionConfiguration.default
+        
+        // 요청 타임아웃 시간 설정 (30초)
+        config.timeoutIntervalForRequest = 30
+        
+        // Alamofire의 Session 생성
+        // - configuration: 위에서 설정한 URLSessionConfig 사용
+        // - interceptor: AuthInterceptor 붙여서 모든 요청/응답을 가로채도록 설정
+        return Session(configuration: config, interceptor: AuthInterceptor())
+    }()
+}

--- a/campick/Services/Network/AuthInterceptor.swift
+++ b/campick/Services/Network/AuthInterceptor.swift
@@ -1,0 +1,51 @@
+//
+//  AuthInterceptor.swift
+//  campick
+//
+//  Created by oyun on 9/17/25.
+//
+
+import Foundation
+import Alamofire
+
+
+// MARK: - 네트워크 요청/응답을 가로채어 공통 처리(토큰 추가, 재시도 등)를 담당하는 Interceptor
+final class AuthInterceptor: RequestInterceptor {
+    
+    // 모든 요청을 서버로 보내기 전에 실행됨 - axios.request.use 같은 역할
+    func adapt(
+        _ urlRequest: URLRequest, // 원본 요청 객체
+        for session: Session, // 현재 Alamofire 세션
+        completion: @escaping (Result<URLRequest, Error>) -> Void
+    ) {
+        var request = urlRequest
+        // Authorization 헤더에 Access Token 자동 추가
+        request.setValue("Bearer \(TokenManager.shared.accessToken)", forHTTPHeaderField: "Authorization")
+        completion(.success(request))
+    }
+
+    
+    // 요청 실패 시(에러 발생) 재시도를 할지 말지 결정하는 메서드
+    func retry(
+        _ request: Request,
+        for session: Session,
+        dueTo error: Error,
+        completion: @escaping (RetryResult) -> Void
+    ) {
+        if let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401 {
+            // 토큰 만료 → refreshToken 실행 ( 미구현 상태 )
+            TokenManager.shared.refreshToken { success in
+                if success {
+                    // 토큰 갱신 성공 시 → 동일 요청을 다시 시도
+                    completion(.retry)
+                } else {
+                    // 토큰 갱신 실패 시 → 재시도하지 않고 에러 그대로 반환
+                    completion(.doNotRetry)
+                }
+            }
+        } else {
+            // 401 이외의 에러는 그냥 재시도하지 않음
+            completion(.doNotRetry)
+        }
+    }
+}

--- a/campick/Services/Network/Endpoints.swift
+++ b/campick/Services/Network/Endpoints.swift
@@ -1,0 +1,33 @@
+//
+//  Endpoints.swift
+//  campick
+//
+//  Created by oyun on 9/17/25.
+//
+
+ 
+// MARK: - API 주소를 정의하는 곳입니다.
+import Foundation
+enum Endpoint: String {
+    case login = "/auth/login"
+    case userInfo = "/user/info"
+    case carInfo = "/car/info"
+
+    var url: String {
+        "https://cam-pick.com/" + rawValue
+    }
+}
+
+// 🚨 사용 예시
+//APIService.shared.request(Endpoint.userInfo.url) // 👉 GET https://api.example.com/user/info
+//    .validate() // 200~299 응답만 success로 처리
+//    .responseDecodable(of: User.self) { response in
+//        switch response.result {
+//        case .success(let user):
+//            print("✅ 유저 정보 로드 성공")
+//            print("ID: \(user.id), 이름: \(user.name), 이메일: \(user.email)")
+//            
+//        case .failure(let error):
+//            print("❌ 유저 정보 로드 실패: \(error.localizedDescription)")
+//        }
+//    }

--- a/campick/Services/Network/TokenManager.swift
+++ b/campick/Services/Network/TokenManager.swift
@@ -1,0 +1,43 @@
+//
+//  TokenManager.swift
+//  campick
+//
+//  Created by oyun on 9/17/25.
+//
+
+import Foundation
+
+
+
+// MARK: - 앱 전체에서 토큰을 관리하는 싱글톤 클래스
+// - accessToken 읽기
+// - accessToken 저장
+// - refreshToken API 호출
+final class TokenManager {
+    // 싱글톤 인스턴스 (앱 전체에서 하나만 사용)
+    static let shared = TokenManager()
+    private init() {}
+
+    // 현재 저장된 Access Token 반환
+    // 없으면 ""(빈 문자열) 리턴
+    var accessToken: String {
+        // TODO: 토큰 저장 코드 구현 부분
+        UserDefaults.standard.string(forKey: "accessToken") ?? "" // 지우면 에러 발생해서 남겨둡니다!
+    }
+
+    // 새로운 Access Token을 저장
+    
+    func saveAccessToken(_ token: String) {
+         // TODO: 토큰 호출 코드 구현 부분
+    }
+
+    // Refresh Token을 이용해 새로운 Access Token 발급받기
+    // 실제 API 호출 부분은 아직 미구현
+    // completion(true) → 갱신 성공
+    // completion(false) → 갱신 실패
+    func refreshToken(completion: @escaping (Bool) -> Void) {
+        // TODO: 실제 refresh API 호출 구현
+        // 성공 시 토큰 업데이트 후 completion(true)
+        completion(false)
+    }
+}


### PR DESCRIPTION
## Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #29 

## Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- Alamofire Session을 활용한 APIService 싱글톤 구성
- RequestInterceptor 구현을 통해 요청/응답 가로채기 처리
    - 요청: Authorization 헤더 자동 부착
    - 응답: 401 or 403 발생 시 토큰 재발급 및 재시도 로직
- Endpoints enum 정의로 API 경로 관리 일원화
- TokenManager 유틸 구현 (accessToken/refreshToken 저장 및 갱신)
- 향후 각 Feature 모듈에서 API 호출 시 공통 APIService 사용하도록 개선


## Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 사용 방법은 Endpoints.swift에 작성되어 있습니다.

