### PR TITLE
#66 feat: 토큰 자동 재발급 및 세션 유지 개선

### DIFF
--- a/campick/ContentView.swift
+++ b/campick/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ContentView: View {
     @StateObject private var userState = UserState.shared
     @StateObject private var network = NetworkMonitor.shared
+    @State private var showSessionExpired = false
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -35,9 +36,62 @@ struct ContentView: View {
             }
         }
         .animation(.easeInOut(duration: 0.25), value: network.isConnected)
+        .onReceive(NotificationCenter.default.publisher(for: .tokenReissueFailed)) { _ in
+            showSessionExpired = true
+        }
+        .sheet(isPresented: $showSessionExpired) {
+            SessionExpiredSheet {
+                showSessionExpired = false
+                UserState.shared.logout()
+            }
+            .presentationDetents([.fraction(0.3)])
+            .presentationDragIndicator(.visible)
+        }
+        .interactiveDismissDisabled(showSessionExpired)
     }
 }
 
 #Preview {
     ContentView()
+}
+
+/// 세션 만료 시 재로그인을 안내하는 바텀 시트
+private struct SessionExpiredSheet: View {
+    let onReLogin: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Capsule()
+                .fill(Color.white.opacity(0.3))
+                .frame(width: 48, height: 5)
+                .padding(.top, 12)
+
+            VStack(spacing: 6) {
+                Text("세션이 만료되었습니다.")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(Color.white)
+                Text("보안을 위해 다시 로그인해 주세요.")
+                    .font(.subheadline)
+                    .foregroundStyle(AppColors.brandWhite70)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, 20)
+
+            Button(action: onReLogin) {
+                Text("재로그인하기")
+                    .font(.system(size: 17, weight: .bold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(AppColors.brandOrange)
+                    .foregroundStyle(Color.white)
+                    .cornerRadius(12)
+            }
+            .padding(.horizontal, 20)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 220)
+        .background(AppColors.background)
+    }
 }

--- a/campick/Models/UserState.swift
+++ b/campick/Models/UserState.swift
@@ -31,10 +31,10 @@ class UserState: ObservableObject {
         dealerId = UserDefaultsManager.getString(forKey: "dealerId") ?? ""
         role = UserDefaultsManager.getString(forKey: "role") ?? ""
 
-        // Check if user has valid token
-        let hasAccessToken = KeychainManager.getToken(forKey: "accessToken") != nil
+        // Keychain에 토큰만 남아 있어도 즉시 로그인 상태를 유지
+        let hasAccessToken = TokenManager.shared.hasValidAccessToken
 
-        isLoggedIn = hasAccessToken && !memberId.isEmpty
+        isLoggedIn = hasAccessToken
     }
 
     func saveUserData(name: String, nickName: String, phoneNumber: String, memberId: String, dealerId: String, role: String) {
@@ -56,7 +56,7 @@ class UserState: ObservableObject {
     }
 
     func saveToken(accessToken: String) {
-        KeychainManager.saveToken(accessToken, forKey: "accessToken")
+        TokenManager.shared.saveAccessToken(accessToken)
 
         if !memberId.isEmpty {
             isLoggedIn = true
@@ -64,8 +64,8 @@ class UserState: ObservableObject {
     }
 
     func logout() {
-        // Clear keychain token
-        KeychainManager.deleteToken(forKey: "accessToken")
+        // Clear keychain token & auto refresh timer
+        TokenManager.shared.clearAll()
 
         // Clear local storage
         UserDefaultsManager.removeValue(forKey: "name")

--- a/campick/Services/AuthAPI.swift
+++ b/campick/Services/AuthAPI.swift
@@ -131,5 +131,21 @@ enum AuthAPI {
         }
     }
 
+    /// 저장된 액세스 토큰으로 재발급을 요청합니다.
+    static func reissueAccessToken() async throws -> String {
+        do {
+            let request = APIService.shared
+                .request(Endpoint.tokenReissue.url, method: .post)
+                .validate()
+            let wrapped = try await request.serializingDecodable(ApiResponse<LoginDataDTO>.self).value
+            guard let token = wrapped.data?.accessToken else {
+                throw AppError.decoding
+            }
+            return token
+        } catch {
+            throw ErrorMapper.map(error)
+        }
+    }
+
     // 회원탈퇴 API는 아직 미구현이므로 연동 제거
 }

--- a/campick/Services/Network/Endpoints.swift
+++ b/campick/Services/Network/Endpoints.swift
@@ -15,6 +15,8 @@ enum Endpoint {
     case emailVerify
     case logout
     case chatList
+    case products
+    case tokenReissue // 토큰 재발급 요청
 
     static let baseURL = "https://campick.shop"
 
@@ -26,6 +28,8 @@ enum Endpoint {
         case .emailVerify: return "/api/member/email/verify"
         case .logout: return "/api/member/logout"
         case .chatList: return "/api/chat/my"
+        case .products: return "/api/product"
+        case .tokenReissue: return "/api/member/reissue"
         }
     }
 

--- a/campick/Utils/Notifications.swift
+++ b/campick/Utils/Notifications.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+extension Notification.Name {
+    /// 토큰 재발급 실패 시 사용자에게 재로그인을 요청하기 위한 알림
+    static let tokenReissueFailed = Notification.Name("campick.tokenReissueFailed")
+}

--- a/campick/ViewModels/LoginViewModel.swift
+++ b/campick/ViewModels/LoginViewModel.swift
@@ -12,6 +12,7 @@ final class LoginViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var errorMessage: String? = nil
     @Published var showServerAlert: Bool = false
+    @Published var showSignupPrompt: Bool = false
 
     var isLoginDisabled: Bool { email.isEmpty || password.isEmpty || isLoading }
 
@@ -19,6 +20,8 @@ final class LoginViewModel: ObservableObject {
         guard !isLoginDisabled else { return }
         isLoading = true
         errorMessage = nil
+        showServerAlert = false
+        showSignupPrompt = false
         Task {
             defer { isLoading = false }
             do {
@@ -44,12 +47,15 @@ final class LoginViewModel: ObservableObject {
                 )
             } catch {
                 if let appError = error as? AppError {
-                    errorMessage = appError.message
                     switch appError {
+                    case .notFound:
+                        errorMessage = nil
+                        showSignupPrompt = true
                     case .cannotConnect, .hostNotFound, .network:
+                        errorMessage = appError.message
                         showServerAlert = true
                     default:
-                        break
+                        errorMessage = appError.message
                     }
                 } else {
                     errorMessage = error.localizedDescription
@@ -58,4 +64,3 @@ final class LoginViewModel: ObservableObject {
         }
     }
 }
-

--- a/campick/Views/Auth/Login/LoginView.swift
+++ b/campick/Views/Auth/Login/LoginView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct LoginView: View {
     @StateObject private var vm = LoginViewModel()
     @StateObject private var userState = UserState.shared
+    @State private var navigateToSignup = false
 
     var body: some View {
         NavigationStack {
@@ -17,6 +18,9 @@ struct LoginView: View {
                 AppColors.background
                     .ignoresSafeArea()
                 VStack(spacing: 4) {
+                    NavigationLink(destination: SignupFlowView(), isActive: $navigateToSignup) {
+                        EmptyView()
+                    }
                     VStack {
                         Text("Campick")
                             .font(.basicFont(size: 40))
@@ -121,9 +125,26 @@ struct LoginView: View {
                     .padding(.top, 112)
                 }
             }
-            .alert("서버 연결이 불안정합니다. 잠시후 다시 시도해 주세요", isPresented: $vm.showServerAlert) {
-                Button("확인", role: .cancel) {}
+        }
+        .alert(
+            "존재하지 않는 사용자입니다.",
+            isPresented: $vm.showSignupPrompt,
+            actions: {
+                Button("Campick과 함께하기") {
+                    DispatchQueue.main.async {
+                        navigateToSignup = true
+                    }
+                }
+                Button("닫기", role: .cancel) {}
+            },
+            message: {
+                Text("Campick과 함께 새로운 계정을 만들어보세요.")
+                    .font(.footnote)
+                    .foregroundColor(AppColors.brandWhite70)
             }
+        )
+        .alert("서버 연결이 불안정합니다. 잠시후 다시 시도해 주세요", isPresented: $vm.showServerAlert) {
+            Button("확인", role: .cancel) {}
         }
     }
 }

--- a/campick/campickApp.swift
+++ b/campick/campickApp.swift
@@ -9,13 +9,30 @@ import SwiftUI
 
 @main
 struct campickApp: App {
+    @Environment(\.scenePhase) private var scenePhase
+
     init() {
-        UserState.shared.loadUserData()
+        UserState.shared.loadUserData() // 저장된 사용자/토큰으로 초기 상태 복원
+        TokenManager.shared.scheduleAutoRefresh()
+        Task {
+            await TokenManager.shared.refreshAccessTokenIfNeeded() // 앱 시작 직후 만료 임박 토큰 갱신
+        }
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
+        }
+        .onChange(of: scenePhase) { newPhase in
+            switch newPhase {
+            case .active:
+                UserState.shared.loadUserData() // 백그라운드에서 돌아와도 로그인 상태를 즉시 복구
+                TokenManager.shared.handleAppDidBecomeActive()
+            case .background:
+                TokenManager.shared.handleAppDidEnterBackground()
+            default:
+                break
+            }
         }
     }
 }


### PR DESCRIPTION
## Related Issue
- close #66
- close #54 

## Summary
- 토큰 재발급 API 연동
      - /api/member/reissue 엔드포인트 정의 및 AuthAPI.reissueAccessToken() 구현
- 자동 재발급/세션 유지 로직
      - TokenManager가 발급 시각을 저장하고 25분마다 재발급 타이머 실행
      - 앱 포어그라운드 전환 시 토큰 상태 재확인·재발급, 백그라운드 진입 시 타이머 유지
      - 재발급 실패 시 NotificationCenter로 알림: tokenReissueFailed → UI에서 처리
 - 세션 만료 UI 처리
      - ContentView에서 재발급 실패 알림을 받으면 “세션이 만료되었습니다. 보안을 위해 다시
  로그인해 주세요.” 모달 표시
      - 모달의 재로그인하기 버튼 선택 시 사용자 로그아웃 후 로그인 화면 이동
- 로그인 상태 판별 개선
      - UserState.loadUserData()가 키체인 토큰 존재 여부만으로도 로그인 상태 유지 → 백그라운
  드 ↔ 포그라운드 전환 시 홈 화면 유지
