### PR TITLE
#47 feat: 매물 찾기 API 연동 및 모델들 생성

### DIFF
--- a/campick/Models/Product/ProductCreateRequest.swift
+++ b/campick/Models/Product/ProductCreateRequest.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// 매물 등록 요청 DTO
+struct ProductCreateRequest: Encodable {
+    let title: String
+    let mileage: String
+    let vehicleType: String
+    let vehicleModel: String
+    let fuelType: String
+    let transmission: String
+    let generation: String
+    let price: String
+    let location: ProductLocationPayload
+    let plateHash: String
+    let description: String
+    let productImageUrl: [String]
+    let option: [ProductOptionPayload]
+}
+
+struct ProductLocationPayload: Codable {
+    let province: String
+    let city: String
+}
+
+struct ProductOptionPayload: Codable {
+    let optionName: String
+    let isInclude: Bool
+}
+

--- a/campick/Models/Product/ProductDetailDTO.swift
+++ b/campick/Models/Product/ProductDetailDTO.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// 매물 상세 조회 응답 DTO
+struct ProductDetailDTO: Decodable {
+    let title: String
+    let generation: String
+    let mileage: String
+    let vehicleType: String
+    let vehicleModel: String
+    let fuelType: String
+    let transmission: String
+    let price: String
+    let location: ProductLocationDTO
+    let user: ProductSellerDTO
+    let plateHash: String
+    let description: String
+    let productImageUrl: [String]
+    let option: [ProductOptionDTO]
+    let isLiked: Bool
+    let status: String
+    let productId: Int
+    let likeCount: Int
+}
+

--- a/campick/Models/Product/ProductItemDTO.swift
+++ b/campick/Models/Product/ProductItemDTO.swift
@@ -1,26 +1,38 @@
 import Foundation
 
-// 서버의 /api/product 응답 중 개별 매물 아이템을 표현하는 DTO
-// 주의: 서버 키 이름과 정확히 일치시키기 위해 CodingKeys 불필요 (동일 케이스)
+/// 매물 목록 조회 시 개별 아이템 DTO
 struct ProductItemDTO: Decodable {
-    // 현재 로그인 사용자가 좋아요한 상태인지 여부
-    let isLiked: Bool
-    // 해당 매물의 좋아요 개수
-    let likeCount: Int
-    // 매물 제목 (예: "현대 아반떼 2021 1.6 가솔린")
-    let title: String
-    // 가격 표시 문자열 (예: "1,150만 원")
-    let price: String
-    // 주행거리 표시 문자열 (예: "42,000 km")
-    let mileage: String
-    // 지역/위치 (예: "서울 강남구")
-    let location: String
-    // 생성 일시(ISO-8601 문자열)
-    let createdAt: String
-    // 썸네일 이미지 절대 URL 문자열
-    let thumbNail: String
-    // 매물 고유 ID
     let productId: Int
-    // 상태 값: "AVAILABLE" | "RESERVED" | "SOLD"
+    let title: String
+    let price: String
+    let mileage: String
+    let vehicleType: String
+    let vehicleModel: String
+    let fuelType: String
+    let transmission: String
+    let location: ProductLocationDTO
+    let createdAt: String
+    let thumbNail: String
+    let isLiked: Bool
+    let likeCount: Int
     let status: String
+}
+
+struct ProductLocationDTO: Codable {
+    let province: String
+    let city: String
+}
+
+struct ProductOptionDTO: Codable {
+    let optionName: String
+    let isInclude: Bool
+}
+
+struct ProductSellerDTO: Decodable {
+    let nickName: String
+    let role: String
+    let rating: Double
+    let sellingCount: Int
+    let completeCount: Int
+    let userId: Int
 }

--- a/campick/Models/Product/ProductItemDTO.swift
+++ b/campick/Models/Product/ProductItemDTO.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+// 서버의 /api/product 응답 중 개별 매물 아이템을 표현하는 DTO
+// 주의: 서버 키 이름과 정확히 일치시키기 위해 CodingKeys 불필요 (동일 케이스)
+struct ProductItemDTO: Decodable {
+    // 현재 로그인 사용자가 좋아요한 상태인지 여부
+    let isLiked: Bool
+    // 해당 매물의 좋아요 개수
+    let likeCount: Int
+    // 매물 제목 (예: "현대 아반떼 2021 1.6 가솔린")
+    let title: String
+    // 가격 표시 문자열 (예: "1,150만 원")
+    let price: String
+    // 주행거리 표시 문자열 (예: "42,000 km")
+    let mileage: String
+    // 지역/위치 (예: "서울 강남구")
+    let location: String
+    // 생성 일시(ISO-8601 문자열)
+    let createdAt: String
+    // 썸네일 이미지 절대 URL 문자열
+    let thumbNail: String
+    // 매물 고유 ID
+    let productId: Int
+    // 상태 값: "AVAILABLE" | "RESERVED" | "SOLD"
+    let status: String
+}

--- a/campick/Models/Product/ProductListDTO.swift
+++ b/campick/Models/Product/ProductListDTO.swift
@@ -1,7 +1,31 @@
 import Foundation
 
 struct ProductListDTO: Decodable {
+    let totalElements: Int
+    let totalPages: Int
+    let size: Int
     let content: [ProductItemDTO]
-    // 기타 페이징 필드는 필요 시 확장
+    let number: Int
+    let sort: ProductSortDTO
+    let pageable: ProductPageableDTO
+    let numberOfElements: Int
+    let first: Bool
+    let last: Bool
+    let empty: Bool
+}
+
+struct ProductSortDTO: Decodable {
+    let empty: Bool
+    let sorted: Bool
+    let unsorted: Bool
+}
+
+struct ProductPageableDTO: Decodable {
+    let offset: Int
+    let sort: ProductSortDTO
+    let paged: Bool
+    let pageNumber: Int
+    let pageSize: Int
+    let unpaged: Bool
 }
 

--- a/campick/Models/Product/ProductListDTO.swift
+++ b/campick/Models/Product/ProductListDTO.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct ProductListDTO: Decodable {
+    let content: [ProductItemDTO]
+    // 기타 페이징 필드는 필요 시 확장
+}
+

--- a/campick/Models/Product/ProductUpdateRequest.swift
+++ b/campick/Models/Product/ProductUpdateRequest.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct ProductUpdateRequest: Encodable {
+    var title: String?
+    var mileage: String?
+    var vehicleType: String?
+    var vehicleModel: String?
+    var fuelType: String?
+    var transmission: String?
+    var generation: String?
+    var price: String?
+    var location: ProductLocationPayload?
+    var plateHash: String?
+    var description: String?
+    var productImageUrl: [String]?
+    var option: [ProductOptionPayload]?
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case mileage
+        case vehicleType
+        case vehicleModel
+        case fuelType
+        case transmission
+        case generation
+        case price
+        case location
+        case plateHash
+        case description
+        case productImageUrl
+        case option
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encodeIfPresent(mileage, forKey: .mileage)
+        try container.encodeIfPresent(vehicleType, forKey: .vehicleType)
+        try container.encodeIfPresent(vehicleModel, forKey: .vehicleModel)
+        try container.encodeIfPresent(fuelType, forKey: .fuelType)
+        try container.encodeIfPresent(transmission, forKey: .transmission)
+        try container.encodeIfPresent(generation, forKey: .generation)
+        try container.encodeIfPresent(price, forKey: .price)
+        try container.encodeIfPresent(location, forKey: .location)
+        try container.encodeIfPresent(plateHash, forKey: .plateHash)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encodeIfPresent(productImageUrl, forKey: .productImageUrl)
+        try container.encodeIfPresent(option, forKey: .option)
+    }
+}
+

--- a/campick/Services/Network/Endpoints.swift
+++ b/campick/Services/Network/Endpoints.swift
@@ -15,6 +15,7 @@ enum Endpoint {
     case emailVerify
     case logout
     case chatList
+    case products
 
     static let baseURL = "https://campick.shop"
 
@@ -26,6 +27,7 @@ enum Endpoint {
         case .emailVerify: return "/api/member/email/verify"
         case .logout: return "/api/member/logout"
         case .chatList: return "/api/chat/my"
+        case .products: return "/api/product"
         }
     }
 

--- a/campick/Services/ProductAPI.swift
+++ b/campick/Services/ProductAPI.swift
@@ -1,0 +1,36 @@
+//
+//  ProductAPI.swift
+//  campick
+//
+//  Created by Assistant on 9/19/25.
+//
+
+import Foundation
+import Alamofire
+
+enum ProductAPI {
+    static func fetchProducts(page: Int? = nil, size: Int? = nil) async throws -> [ProductItemDTO] {
+        do {
+            var params: [String: Any] = [:]
+            if let page = page { params["page"] = page }
+            if let size = size { params["size"] = size }
+
+            let parameters: [String: Any]? = params.isEmpty ? nil : params
+
+            let request = APIService.shared
+                .request(
+                    Endpoint.products.url,
+                    method: .get,
+                    parameters: parameters,
+                    encoding: URLEncoding.default
+                )
+                .validate()
+            // 서버 응답: ApiResponse<ProductListDTO>
+            let wrapped = try await request.serializingDecodable(ApiResponse<ProductListDTO>.self).value
+            return wrapped.data?.content ?? []
+        } catch {
+            throw ErrorMapper.map(error)
+        }
+    }
+}
+

--- a/campick/Services/ProductAPI.swift
+++ b/campick/Services/ProductAPI.swift
@@ -9,7 +9,7 @@ import Foundation
 import Alamofire
 
 enum ProductAPI {
-    static func fetchProducts(page: Int? = nil, size: Int? = nil) async throws -> [ProductItemDTO] {
+    static func fetchProducts(page: Int? = nil, size: Int? = nil) async throws -> ProductListDTO {
         do {
             var params: [String: Any] = [:]
             if let page = page { params["page"] = page }
@@ -27,10 +27,10 @@ enum ProductAPI {
                 .validate()
             // 서버 응답: ApiResponse<ProductListDTO>
             let wrapped = try await request.serializingDecodable(ApiResponse<ProductListDTO>.self).value
-            return wrapped.data?.content ?? []
+            guard let list = wrapped.data else { return ProductListDTO(totalElements: 0, totalPages: 0, size: 0, content: [], number: 0, sort: ProductSortDTO(empty: true, sorted: false, unsorted: true), pageable: ProductPageableDTO(offset: 0, sort: ProductSortDTO(empty: true, sorted: false, unsorted: true), paged: true, pageNumber: 0, pageSize: 0, unpaged: true), numberOfElements: 0, first: true, last: true, empty: true) }
+            return list
         } catch {
             throw ErrorMapper.map(error)
         }
     }
 }
-


### PR DESCRIPTION
## Related Issue
- close #47 

##  🚨주의!!!
현재 서버에서 전달 데이터가 수정되지 않으면 동작하지 않음.

## Summary
- 모델 전면 개편
      - ProductItemDTO, ProductListDTO를 새 API 응답 구조(차량 정보·위치·페이징 메타데이터
  포함)에 맞게 재정의
      - 상세/등록/수정용 DTO(ProductDetailDTO, ProductCreateRequest, ProductUpdateRequest)
  추가
      - 공용 서브 DTO(ProductLocationDTO, ProductOptionDTO, ProductSellerDTO,
  ProductSortDTO, ProductPageableDTO) 도입
- 서비스/뷰모델 연동
      - ProductAPI.fetchProducts()가 ApiResponse<ProductListDTO> 전체를 반환하도록 변경
      - FindVehicleViewModel에서 새 DTO를 사용해 Vehicle로 매핑 및 정렬/필터 로직 유지