### PR TITLE
#107 feat(auth): 로그아웃 API 연동 정정 및 로깅

### DIFF
--- a/campick/Services/AuthService.swift
+++ b/campick/Services/AuthService.swift
@@ -13,13 +13,17 @@ class AuthService: ObservableObject {
 
     private init() {}
 
-    // 로그아웃 API 호출 (Alamofire 사용)
+    // 로그아웃 API 호출: AuthAPI 사용해 토큰 포함 POST /api/member/logout 요청
     func logout() async throws {
-        let url = "http://localhost:8080/api/member/logout"
-        let request = APIService.shared
-            .request(url, method: .post)
-            .validate()
-        _ = try await request.serializingData().value
+        do {
+            AppLog.info("Requesting logout", category: "AUTH")
+            try await AuthAPI.logout()
+            AppLog.info("Logout success", category: "AUTH")
+        } catch {
+            let appError = ErrorMapper.map(error)
+            AppLog.error("Logout failed: \(appError.message)", category: "AUTH")
+            throw appError
+        }
     }
 
     // 회원탈퇴 API 미구현: 현재는 사용하지 않음

--- a/campick/ViewModels/HomeProfileViewModel.swift
+++ b/campick/ViewModels/HomeProfileViewModel.swift
@@ -12,15 +12,17 @@ final class HomeProfileViewModel: ObservableObject {
     func logout() {
         Task {
             do {
+                AppLog.info("Requesting logout", category: "AUTH")
                 try await AuthAPI.logout()
+                AppLog.info("Logout success", category: "AUTH")
             } catch {
-                // 서버 실패 시에도 로컬 세션은 종료
+                let appError = ErrorMapper.map(error)
+                AppLog.error("Logout failed: \(appError.message)", category: "AUTH")
             }
             await MainActor.run { UserState.shared.logout() }
         }
     }
 
 }
-
 
 

--- a/campick/Views/ProfileView.swift
+++ b/campick/Views/ProfileView.swift
@@ -204,9 +204,12 @@ struct ProfileView: View {
     private func logout() {
         Task {
             do {
+                AppLog.info("Requesting logout", category: "AUTH")
                 try await AuthService.shared.logout()
+                AppLog.info("Logout success", category: "AUTH")
             } catch {
-                // 서버 실패 시에도 로컬 세션은 종료
+                let appError = ErrorMapper.map(error)
+                AppLog.error("Logout failed: \(appError.message)", category: "AUTH")
             }
             await MainActor.run { UserState.shared.logout() }
         }


### PR DESCRIPTION
## Related Issue
- close #107 

## Summary
- AuthService.logout → AuthAPI.logout 사용으로 정정(토큰 포함)
- AppLog로 요청/성공/실패 로깅 추가
- AppError 매핑 후 에러 전파