### PR TITLE
#106 feat(api): 제품 목록 조회 필터/정렬 스펙 반영 및 엔드포인트 교정

### DIFF
--- a/campick/Models/Product/ProductFilterRequest.swift
+++ b/campick/Models/Product/ProductFilterRequest.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct ProductFilterRequest: Encodable {
+    let mileageFrom: Int?
+    let mileageTo: Int?
+    let costFrom: Int?
+    let costTo: Int?
+    let generationFrom: Int?
+    let generationTo: Int?
+    let types: [String]?
+
+    init(
+        mileageFrom: Int? = nil,
+        mileageTo: Int? = nil,
+        costFrom: Int? = nil,
+        costTo: Int? = nil,
+        generationFrom: Int? = nil,
+        generationTo: Int? = nil,
+        types: [String]? = nil
+    ) {
+        self.mileageFrom = mileageFrom
+        self.mileageTo = mileageTo
+        self.costFrom = costFrom
+        self.costTo = costTo
+        self.generationFrom = generationFrom
+        self.generationTo = generationTo
+        self.types = types
+    }
+}
+
+enum ProductSort: String {
+    case createdAtDesc
+    case costAsc
+    case costDesc
+    case mileageAsc
+    case generationDesc
+
+    var queryValue: String {
+        switch self {
+        case .createdAtDesc: return "createdAt,desc"
+        case .costAsc: return "cost,asc"
+        case .costDesc: return "cost,desc"
+        case .mileageAsc: return "mileage,asc"
+        case .generationDesc: return "generation,desc"
+        }
+    }
+}
+

--- a/campick/Services/Network/Endpoints.swift
+++ b/campick/Services/Network/Endpoints.swift
@@ -45,7 +45,7 @@ enum Endpoint {
         case .carRecommend: return "/api/product/recommend"
         case .logout: return "/api/member/logout"
         case .chatList: return "/api/chat/my"
-        case .products: return "/api/product"
+        case .products: return "/api/products"
         case .tokenReissue: return "/api/member/reissue"
         case .memberInfo(let memberId): return "/api/member/info/\(memberId)"
         case .memberProducts(let memberId): return "/api/member/product/all/\(memberId)"

--- a/campick/Services/ProductAPI.swift
+++ b/campick/Services/ProductAPI.swift
@@ -25,11 +25,30 @@ enum ProductAPI {
         }
     }
 
-    static func fetchProducts(page: Int? = nil, size: Int? = nil) async throws -> Page<ProductItemDTO> {
+    static func fetchProducts(
+        page: Int? = nil,
+        size: Int? = nil,
+        filter: ProductFilterRequest? = nil,
+        sort: ProductSort? = nil
+    ) async throws -> Page<ProductItemDTO> {
         do {
             var params: [String: Any] = [:]
             if let page = page { params["page"] = page }
             if let size = size { params["size"] = size }
+            if let f = filter {
+                if let v = f.mileageFrom { params["mileageFrom"] = v }
+                if let v = f.mileageTo { params["mileageTo"] = v }
+                if let v = f.costFrom { params["costFrom"] = v }
+                if let v = f.costTo { params["costTo"] = v }
+                if let v = f.generationFrom { params["generationFrom"] = v }
+                if let v = f.generationTo { params["generationTo"] = v }
+                if let types = f.types, !types.isEmpty {
+                    params["types"] = types // encode as repeated keys
+                }
+            }
+            if let sort = sort {
+                params["sort"] = sort.queryValue
+            }
 
             let parameters: [String: Any]? = params.isEmpty ? nil : params
 
@@ -38,7 +57,7 @@ enum ProductAPI {
                     Endpoint.products.url,
                     method: .get,
                     parameters: parameters,
-                    encoding: URLEncoding.default
+                    encoding: URLEncoding(destination: .methodDependent, arrayEncoding: .noBrackets, boolEncoding: .literal)
                 )
                 .validate()
             // 서버 응답: ApiResponse<Page<ProductItemDTO>>

--- a/campick/Views/Components/FlowLayout.swift
+++ b/campick/Views/Components/FlowLayout.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// A simple flow layout that lays out subviews horizontally and wraps to the next line as needed.
+struct FlowLayout: Layout {
+    var horizontalSpacing: CGFloat = 8
+    var verticalSpacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? UIScreen.main.bounds.width
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > 0 && x + size.width > maxWidth {
+                // wrap
+                x = 0
+                y += rowHeight + verticalSpacing
+                rowHeight = 0
+            }
+            rowHeight = max(rowHeight, size.height)
+            x += size.width + horizontalSpacing
+        }
+        return CGSize(width: maxWidth, height: y + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let maxWidth = bounds.width
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > 0 && x + size.width > maxWidth {
+                // wrap
+                x = 0
+                y += rowHeight + verticalSpacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: bounds.minX + x, y: bounds.minY + y), proposal: ProposedViewSize(width: size.width, height: size.height))
+            x += size.width + horizontalSpacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+

--- a/campick/Views/Components/VehicleFinder/FilterView.swift
+++ b/campick/Views/Components/VehicleFinder/FilterView.swift
@@ -6,14 +6,32 @@
 //
 
 import SwiftUI
+import Foundation
 
 struct FilterOptions: Equatable {
-    var priceRange: ClosedRange<Double> = 0...10000
-    var mileageRange: ClosedRange<Double> = 0...100000
-    var yearRange: ClosedRange<Double> = 2010...2024
-    var selectedVehicleTypes: Set<String> = []
-    var selectedFuelTypes: Set<String> = []
-    var selectedTransmissions: Set<String> = []
+    var priceRange: ClosedRange<Double>
+    var mileageRange: ClosedRange<Double>
+    var yearRange: ClosedRange<Double>
+    var selectedVehicleTypes: Set<String>
+    var selectedFuelTypes: Set<String>
+    var selectedTransmissions: Set<String>
+
+    init(
+        priceRange: ClosedRange<Double> = 0...10000,
+        mileageRange: ClosedRange<Double> = 0...100000,
+        yearRange: ClosedRange<Double>? = nil,
+        selectedVehicleTypes: Set<String> = [],
+        selectedFuelTypes: Set<String> = [],
+        selectedTransmissions: Set<String> = []
+    ) {
+        self.priceRange = priceRange
+        self.mileageRange = mileageRange
+        let currentYear = Double(Calendar.current.component(.year, from: Date()))
+        self.yearRange = yearRange ?? 1990...currentYear
+        self.selectedVehicleTypes = selectedVehicleTypes
+        self.selectedFuelTypes = selectedFuelTypes
+        self.selectedTransmissions = selectedTransmissions
+    }
 }
 
 struct FilterView: View {
@@ -169,9 +187,10 @@ struct FilterView: View {
                 .foregroundColor(.white)
 
             VStack(spacing: 12) {
+                let currentYear = Double(Calendar.current.component(.year, from: Date()))
                 RangeSlider(
                     range: $tempFilters.yearRange,
-                    bounds: 2010...2024,
+                    bounds: 1990...currentYear,
                     step: 1
                 )
 


### PR DESCRIPTION
## Related Issue
- close #106 

## Summary
- Endpoint.products를 "/api/products"로 수정
- ProductFilterRequest, ProductSort 추가(쿼리 필터/정렬 지원)
- ProductAPI.fetchProducts(page:size:filter:sort:)로 시그니처 확장
- 쿼리 빌드: 범위/타입/정렬 파라미터 반영
- types 전송을 반복 키 방식으로 변경(URLEncoding arrayEncoding: .noBrackets)