### PR TITLE
#94 feat(product-like): 차량 카드 좋아요 API 연동

### DIFF
--- a/campick/Services/Network/Endpoints.swift
+++ b/campick/Services/Network/Endpoints.swift
@@ -51,7 +51,7 @@ enum Endpoint {
         case .carRecommend: return "/api/product/recommend"
         case .logout: return "/api/member/logout"
         case .chatList: return "/api/chat/my"
-        case .products: return "/api/products"
+        case .products: return "/api/product"
         case .tokenReissue: return "/api/member/reissue"
         case .memberInfo(let memberId): return "/api/member/info/\(memberId)"
         case .memberProducts(let memberId): return "/api/member/product/all/\(memberId)"

--- a/campick/Services/ProductAPI.swift
+++ b/campick/Services/ProductAPI.swift
@@ -98,4 +98,17 @@ enum ProductAPI {
             throw ErrorMapper.map(error)
         }
     }
+
+    // 좋아요 토글 (PATCH /api/product/{productId}/like)
+    static func likeProduct(productId: String) async throws {
+        do {
+            AppLog.info("Like product: \(productId)", category: "PRODUCT")
+            let request = APIService.shared
+                .request(Endpoint.productLike(productId: productId).url, method: .patch)
+                .validate()
+            _ = try await request.serializingData().value
+        } catch {
+            throw ErrorMapper.map(error)
+        }
+    }
 }


### PR DESCRIPTION
## Related Issue
- close #94 

## Summary
- ProductAPI.likeProduct(productId:) 추가(PATCH /api/product/{productId}/like)
- VehicleCardViewModel에 productId 보관 및 낙관적 토글 적용
- 실패 시 AppError 매핑/로그 기록 후 즐겨찾기 상태 롤백
- VehicleCardView의 하트 버튼은 기존 액션(vm.toggleFavorite)으로 동작 유지