### PR TITLE
#142 fix(camera): 카메라 사용 화면에 .ignoresSafeArea 적용

### DIFF
--- a/campick/Views/Components/Media/MediaPickerSheet.swift
+++ b/campick/Views/Components/Media/MediaPickerSheet.swift
@@ -31,6 +31,7 @@ struct MediaPickerSheet: View {
             case .camera:
                 if cameraPermissionChecked && cameraAuthorized {
                     ImagePickerView(sourceType: .camera, selectedImage: $selectedImage)
+                        .ignoresSafeArea()
                 } else if cameraPermissionChecked && !cameraAuthorized {
                     PermissionDeniedView(
                         title: "카메라 접근 권한 필요",

--- a/campick/Views/Components/VehicleRegistration/VehicleImageUploadSection.swift
+++ b/campick/Views/Components/VehicleRegistration/VehicleImageUploadSection.swift
@@ -63,6 +63,7 @@ struct VehicleImageUploadSection: View {
                 }
                 showingCamera = false
             }
+            .ignoresSafeArea()
         }
         .sheet(isPresented: $showingMainImagePicker) {
             CropEnabledImagePickerView { croppedImage in


### PR DESCRIPTION
## Related Issue
- close #142 

## Summary
- VehicleImageUploadSection: CameraView를 전체화면으로 표시하도록 .ignoresSafeArea() 추가
- MediaPickerSheet(.camera): ImagePickerView에 .ignoresSafeArea() 적용해 시트 내 카메라 전체화면 표시
- 채팅 화면의 카메라(fullScreenCover)는 기존 .ignoresSafeArea 적용 상태 유지