### PR TITLE
#146 fix(detail): 헤더 이미지 Safe Area 확장 및 상단 잘림 보정

### DIFF
--- a/campick/Views/Components/VehicleDetail/VehicleImageGallery.swift
+++ b/campick/Views/Components/VehicleDetail/VehicleImageGallery.swift
@@ -26,7 +26,9 @@ struct VehicleImageGallery: View {
                             .tag(index)
                     }
                 }
-                .frame(height: 250)
+                // 헤더 이미지가 상단 안전영역까지 확장되도록 safeArea 상단만큼 높이를 늘리고, 위로 당겨 붙입니다.
+                .frame(height: 250 + topSafeArea)
+                .padding(.top, -topSafeArea)
                 .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
 
                 VStack {
@@ -161,7 +163,15 @@ struct VehicleImageGallery: View {
             }
             .padding(.vertical, 16)
         }
+        .ignoresSafeArea(edges: .top)
     }
+}
+
+private var topSafeArea: CGFloat {
+    let scenes = UIApplication.shared.connectedScenes
+    let windowScene = scenes.first as? UIWindowScene
+    let window = windowScene?.windows.first { $0.isKeyWindow }
+    return window?.safeAreaInsets.top ?? 0
 }
 
 struct ThumbnailImageView: View {

--- a/campick/Views/VehicleDetailView.swift
+++ b/campick/Views/VehicleDetailView.swift
@@ -45,6 +45,7 @@ struct VehicleDetailView: View {
                             showsEditButton: isOwner,
                             onEditTap: { navigateToEdit = true }
                         )
+                        .ignoresSafeArea(edges: .top)
                     }
                     
                     VStack(spacing: 20) {
@@ -179,6 +180,6 @@ struct VehicleDetailView: View {
 
 #Preview {
     NavigationView {
-        VehicleDetailView(vehicleId: "104")
+        VehicleDetailView(vehicleId: "1")
     }
 }


### PR DESCRIPTION
## Related Issue
- close #146 

## Summary
- VehicleDetailView/VehicleImageGallery에 상단 safe area 무시 적용
- 헤더 TabView 높이를 safe area 상단 inset만큼 확장하고 음수 패딩으로 상단에 밀착
- 상단 노치/상태바 영역까지 이미지가 자연스럽게 채워지도록 개선