### PR TITLE
#150 feat(profile): 판매자 프로필 상세에서 TopBar 숨김 + 상단 여백 보정

### DIFF
--- a/campick/RootView.swift
+++ b/campick/RootView.swift
@@ -30,7 +30,7 @@ struct RootView: View {
                                 case .favorites:
                                     FavoritesView()
                                 case .profile:
-                                    ProfileView(memberId: userState.memberId.isEmpty ? nil : userState.memberId, isOwnProfile: true, showBackButton: false)
+                                    ProfileView(memberId: userState.memberId.isEmpty ? nil : userState.memberId, isOwnProfile: true, showBackButton: false, showTopBar: true)
                                 }
                             }
                             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/campick/Views/Components/Home/ProfileMenu.swift
+++ b/campick/Views/Components/Home/ProfileMenu.swift
@@ -144,7 +144,7 @@ struct ProfileMenu: View {
                     .ignoresSafeArea()
                 }
                 .navigationDestination(isPresented: $navigateToProfile) {
-                    ProfileView(memberId: userState.memberId, isOwnProfile: true)
+                    ProfileView(memberId: userState.memberId, isOwnProfile: true, showBackButton: true, showTopBar: true)
                 }
                 .frame(width: 280)
                 .offset(x: showSlideMenu ? 0 : 300) // 오른쪽에서 슬라이드

--- a/campick/Views/Components/VehicleDetail/SellerModalView.swift
+++ b/campick/Views/Components/VehicleDetail/SellerModalView.swift
@@ -52,7 +52,8 @@ struct SellerModalView: View {
                 }
             }
             .navigationDestination(isPresented: $showSellerProfile) {
-                ProfileView(memberId: viewModel.seller.id, isOwnProfile: false, showBackButton: true)
+                // 판매자 프로필 상세에서는 TopBar 미노출
+                ProfileView(memberId: viewModel.seller.id, isOwnProfile: false, showBackButton: true, showTopBar: false)
             }
         }
     }

--- a/campick/Views/ProfileView.swift
+++ b/campick/Views/ProfileView.swift
@@ -11,6 +11,7 @@ struct ProfileView: View {
     let memberId: String?
     let isOwnProfile: Bool
     let showBackButton: Bool // 뒤로가기 버튼 표시 여부
+    let showTopBar: Bool // 상단 TopBar 노출 여부
 
     @StateObject private var profileDataViewModel = ProfileDataViewModel()
     @StateObject private var userState = UserState.shared
@@ -35,10 +36,11 @@ struct ProfileView: View {
         }
     }
 
-    init(memberId: String? = nil, isOwnProfile: Bool, showBackButton: Bool = true) {
+    init(memberId: String? = nil, isOwnProfile: Bool, showBackButton: Bool = true, showTopBar: Bool = true) {
         self.memberId = memberId
         self.isOwnProfile = isOwnProfile
         self.showBackButton = showBackButton
+        self.showTopBar = showTopBar
     }
 
     var body: some View {
@@ -47,17 +49,18 @@ struct ProfileView: View {
                 .ignoresSafeArea()
 
             VStack(spacing: 0) {
-                if showBackButton { // 뒤로가기 버튼이 필요한 경우
-                    TopBarView(title: "내 프로필", showsBackButton: true) {
-                        dismiss()
+                if showTopBar {
+                    if showBackButton { // 뒤로가기 버튼이 필요한 경우
+                        TopBarView(title: "내 프로필", showsBackButton: true) {
+                            dismiss()
+                        }
+                        .padding(.top, 6)
+                        .padding(.bottom, 12)
+                    } else {
+                        TopBarView(title: "내 프로필", showsBackButton: false)
+                            .padding(.top, 6)
+                            .padding(.bottom, 12)
                     }
-                        .padding(.top, 6)
-                        .padding(.bottom, 12)
-                } else {
-                    TopBarView(title: "내 프로필", showsBackButton: false)
-                        .padding(.top, 6)
-                        .padding(.bottom, 12)
-                    
                 }
                 
 
@@ -130,6 +133,7 @@ struct ProfileView: View {
                     }
                 }
             }
+            .padding(.top, showTopBar ? 0 : 30)
         }
         .navigationBarHidden(true)
         .toolbar(.hidden, for: .navigationBar)


### PR DESCRIPTION
## Related Issue
- close #150 

## Summary
- ProfileView에 showTopBar 플래그 추가(조건부 렌더링)
- 판매자 모달 → 프로필 상세 경로에서 showTopBar=false 적용
- TopBar 숨김 시 로 상단 여백 보정
- 일반 프로필 진입은 기존대로 TopBar 노출 유지