### PR TITLE
#164 fix(chat): 채팅에서 ‘매물 찾아보기’ 시 탭바 유지되도록 라우팅 수정

### DIFF
--- a/campick/Views/ChatRoomListView.swift
+++ b/campick/Views/ChatRoomListView.swift
@@ -67,6 +67,7 @@ struct ChatRoomListView: View {
 //        )
     ]
     @State private var showFindVehicle = false
+    @EnvironmentObject private var tabRouter: TabRouter
     @StateObject private var viewModel = ChatListViewModel()
     @Environment(\.dismiss) private var dismiss
     var body: some View {
@@ -95,7 +96,10 @@ struct ChatRoomListView: View {
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
                         .padding(.bottom, 16)
-                    Button(action: { showFindVehicle = true }) {
+                    Button(action: {
+                        tabRouter.navigateToVehicles(with: nil)
+                        dismiss()
+                    }) {
                         Text("매물 찾아보기")
                             .padding()
                             .frame(maxWidth: .infinity)
@@ -106,9 +110,7 @@ struct ChatRoomListView: View {
                     .padding(.horizontal, 20)
                 }
                 .frame(maxHeight: .infinity)
-                .fullScreenCover(isPresented: $showFindVehicle) {
-                    FindVehicleView()
-                }
+                
             } else {
                 //더미
 //                List {


### PR DESCRIPTION
## Related Issue
- close #164 

## Summary
- fullScreenCover로 FindVehicleView를 표시하던 방식을 제거
- TabRouter.navigateToVehicles 호출 + dismiss로 RootView 컨테이너 내 전환
- BottomTabBar가 포함된 상태에서 매물 찾기 화면 표시