### PR TITLE
#181 feat(SSLPinning) : SSL Pinning 기능 구현

### DIFF
--- a/campick/Info.plist
+++ b/campick/Info.plist
@@ -6,6 +6,21 @@
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
+		<key>NSPinnedDomains</key>
+		<dict>
+			<key>campick.shop</key>
+			<dict>
+        <key>NSPinnedLeafIdentities</key>
+        <array>
+          <dict>
+            <key>SPKI-SHA256-BASE64</key>
+            <string>zl7w9TnvVV4VXqpG2nIB3V4iapuAuk2+PMBmZl3lZVE=</string>
+          </dict>
+        </array>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
 	</dict>
 	<key>UIAppFonts</key>
 	<array>


### PR DESCRIPTION
## Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #181 

## 추가하려는 기능에 대해 설명해주세요
- campick.shop 에 대해 인증서의 해시값을 사전 등록된 공개키를 통해 검증합니다

## 기능 설명

- 중간자 공격을 방어하기 위해 CA에서 발행하는 인증서를 통해서 앱 패키지 내에 미리 등록된 campick 서버의 공개키를 통해서 우리의 서버인지 검증을 합니다


## 참고 자료
- 1번자료 : [Alamofire 공식 문서 중 ServerTrustManager 항목](https://github.com/Alamofire/Alamofire/blob/master/Documentation/AdvancedUsage.md#session)
- 2번 자료 : [Apple Developer 공식문서](https://developer.apple.com/documentation/security/preventing-insecure-network-connections#Ensure-the-Network-Server-Meets-Minimum-Requirements)

