### PR TITLE
#190 fix(chat): 채팅방 & 채팅 리스트 버그 수정

### DIFF
--- a/campick.xcodeproj/project.pbxproj
+++ b/campick.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kinggg.campick;
+				PRODUCT_BUNDLE_IDENTIFIER = com.koyun.campick;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -350,7 +350,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kinggg.campick;
+				PRODUCT_BUNDLE_IDENTIFIER = com.koyun.campick;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/campick/Info.plist
+++ b/campick/Info.plist
@@ -10,15 +10,15 @@
 		<dict>
 			<key>campick.shop</key>
 			<dict>
-        <key>NSPinnedLeafIdentities</key>
-        <array>
-          <dict>
-            <key>SPKI-SHA256-BASE64</key>
-            <string>zl7w9TnvVV4VXqpG2nIB3V4iapuAuk2+PMBmZl3lZVE=</string>
-          </dict>
-        </array>
 				<key>NSIncludesSubdomains</key>
 				<true/>
+				<key>NSPinnedLeafIdentities</key>
+				<array>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>zl7w9TnvVV4VXqpG2nIB3V4iapuAuk2+PMBmZl3lZVE=</string>
+					</dict>
+				</array>
 			</dict>
 		</dict>
 	</dict>

--- a/campick/Services/Network/WebSocket.swift
+++ b/campick/Services/Network/WebSocket.swift
@@ -148,6 +148,7 @@ struct ReceivedChatMessagePayload: Decodable {
 }
 
 struct ReceivedChatMessageData: Decodable {
+    let chatId: Int
     let content: String
     let senderId: Int
     let sendAt: String

--- a/campick/ViewModels/ChatViewModel.swift
+++ b/campick/ViewModels/ChatViewModel.swift
@@ -66,6 +66,12 @@ final class ChatViewModel: ObservableObject {
             
             switch response {
             case .chat(let chatData):
+                
+                guard chatData.chatId == chatId else {
+                                print("무시: 다른 채팅방 메시지")
+                                return
+                            }
+                
                 let key = self.makeOptimisticKey(content: chatData.content, senderId: chatData.senderId)
                 let chat = Chat(
                     message: chatData.content,

--- a/campick/Views/ChatRoomListView.swift
+++ b/campick/Views/ChatRoomListView.swift
@@ -61,7 +61,7 @@ struct ChatRoomListView: View {
                 
             } else {
                 List {
-                    ForEach(viewModel.chats) { room in
+                    ForEach(viewModel.chats.reversed()) { room in
                         ChatRoomRow(room: room)
                             .onTapGesture {
                                 selectedRoom = room

--- a/campick/Views/ChatRoomListView.swift
+++ b/campick/Views/ChatRoomListView.swift
@@ -73,7 +73,8 @@ struct ChatRoomListView: View {
                     }
                     .onDelete { indexSet in
                         for index in indexSet {
-                            let room = viewModel.chats[index]
+                            let reversedChats = Array(viewModel.chats.reversed())
+                            let room = reversedChats[index]
                             ChatService.shared.leaveChatRoom(chatRoomId: room.id) { result in
                                 switch result {
                                 case .success:
@@ -82,8 +83,10 @@ struct ChatRoomListView: View {
                                     print("채팅방 나가기 실패: \(error.localizedDescription)")
                                 }
                             }
+                            if let originalIndex = viewModel.chats.firstIndex(where: { $0.id == room.id }) {
+                                viewModel.chats.remove(at: originalIndex)
+                            }
                         }
-                        viewModel.chats.remove(atOffsets: indexSet)
                     }
                 }
                 .listStyle(.plain)


### PR DESCRIPTION
## Related Issue
<!-- 관련 이슈를 적어주세요. -->
- #190

## Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 채팅방
   - 기존 채팅은 모든 채팅에 관한 메시지를 수신했습니다. 
   - 현재 속해 있는 chatRoomId를 통해 현재 채팅방의 메시지만 수신하도록 수정했습니다.

- 채팅 리스트
   - 기존 채팅 리스트 데이터는 최신순이 가장 끝 순서로 전달되었습니다.
   - 채팅 리스트를 역순(최신) 정렬(reverse) 했습니다.
